### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ You are now ready to dive deeper into the specifics of [job configuration](https
 
 |   | Command              |        Description                                                        |
 |-----------| -------------------------- | -------------------------------------------------------------- |
-|⏳| [`mle init`](https://roberttlange.github.io/mle-toolbox/core_api/mle_init/)       | Start up an experiment.              |
-|🚀| [`mle run`](https://roberttlange.github.io/mle-toolbox/core_api/mle_run/)       | Setup of credentials & toolbox settings.              |
+|⏳| [`mle init`](https://roberttlange.github.io/mle-toolbox/core_api/mle_init/)       | Setup of credentials & toolbox settings.              |
+|🚀| [`mle run`](https://roberttlange.github.io/mle-toolbox/core_api/mle_run/)       | Start up an experiment.              |
 |🖥️| [`mle monitor`](https://roberttlange.github.io/mle-toolbox/core_api/mle_monitor/)       | Monitor resource utilisation.              |
 |📥	| [`mle retrieve`](https://roberttlange.github.io/mle-toolbox/core_api/mle_retrieve/)       | Retrieve an experiment result.              |
 |💌| [`mle report`](https://roberttlange.github.io/mle-toolbox/core_api/mle_report/)       | Create an experiment report with figures.              |


### PR DESCRIPTION
`mle init` and `mle run` description was flipped